### PR TITLE
Add bootstrap log bundle and masters-gather script to master ignition

### DIFF
--- a/data/data/bootstrap/bootstrap-in-place/opt/openshift/bootstrap-in-place/master-update.fcc
+++ b/data/data/bootstrap/bootstrap-in-place/opt/openshift/bootstrap-in-place/master-update.fcc
@@ -37,6 +37,13 @@ storage:
       contents:
         local: bootstrap-in-place/bootstrap-in-place-post-reboot.sh
       mode: 0555
+    - path: /var/log/log-bundle-bootstrap-in-place-pre-reboot.tar.gz
+      contents:
+        local: log-bundle-bootstrap-in-place-pre-reboot.tar.gz
+    - path: /usr/local/bin/installer-masters-gather.sh
+      contents:
+        local: installer-masters-gather.sh
+      mode: 0555
 systemd:
   units:
     - name: bootstrap-in-place-post-reboot.service

--- a/data/data/bootstrap/bootstrap-in-place/usr/local/bin/bootstrap-in-place.sh.template
+++ b/data/data/bootstrap/bootstrap-in-place/usr/local/bin/bootstrap-in-place.sh.template
@@ -29,7 +29,16 @@ if [ ! -f master-ignition.done ]; then
   curl --header "Accept:'application/vnd.coreos.ignition+json;version=3.1.0 ;q=0.1'" \
     http://localhost:22624/config/master -o /opt/openshift/original-master.ign
 
-  echo "Adding bootstrap control plane to master ignition"
+  GATHER_ID="bootstrap-in-place-pre-reboot"
+  GATHER_TAR_FILE=log-bundle-${GATHER_ID}.tar.gz
+
+  echo "Gathering installer bootstrap logs"
+  TAR_FILE=${GATHER_TAR_FILE} /usr/local/bin/installer-gather.sh --id $GATHER_ID
+
+  echo "Include installer-masters-gather script in ignition assets"
+  cp /usr/local/bin/installer-masters-gather.sh .
+
+  echo "Adding bootstrap control plane and bootstrap installer-gather bundle to master ignition"
   bootkube_podman_run \
     --rm \
     --privileged \
@@ -37,7 +46,11 @@ if [ ! -f master-ignition.done ]; then
     --volume "/var/lib/etcd/:/assets/etcd-data" \
     --volume "/etc/kubernetes:/assets/kubernetes" \
     "${CLUSTER_BOOTSTRAP_IMAGE}" \
-    bootstrap-in-place --asset-dir /assets --input  /assets/bootstrap-in-place/master-update.fcc --output /assets/master.ign
+    bootstrap-in-place \
+    --asset-dir /assets \
+    --input /assets/bootstrap-in-place/master-update.fcc \
+    --output /assets/master.ign
+
   touch master-ignition.done
 fi
 


### PR DESCRIPTION
This PR lays the groundwork for making log gathering on BiP possible. 

# Bootstrap gather
Before reboot, bootstrap will gather from itself using `/usr/local/bin/installer-gather.sh`. This script also tries to gather from the masters in the cluster, but since there are none, it will only gather about itself.

After the gathering is complete, the bundle is added to the master ignition - thus making the bootstrap logs available from the master after reboot.

# Master gather
Typically, in non-BiP scenarios, masters are gathered via the bootstrap node using the script mentioned above (it runs on the bootstrap). That script detects all masters (or receives a list of masters via a commandline argument), then for each master it `scp`s a second script, `/usr/local/bin/installer-masters-gather.sh` to that master, then it runs it remotely on that master with `ssh`, then it `scp`s the resulting files back to the bootstrap node, adding them to the bootstrap log bundle under a directory for each master.

In the BiP scenario, we simply copy the `/usr/local/bin/installer-masters-gather.sh` script as part of the master ignition, to make it available for later use without requiring a bootstrap node to copy it each time logs need to be gathered.

# Future plans:
- Detect (from outside) whether node is currently in bootstrap or not in order to know how to gather logs from it
- Trigger gathering manually via our scripts
- Modify regular gather cmd to behave correctly when using BiP






