### PR TITLE
Bootstrap in place gather command support

### DIFF
--- a/data/data/bootstrap/bootstrap-in-place/opt/openshift/bootstrap-in-place/master-update.fcc
+++ b/data/data/bootstrap/bootstrap-in-place/opt/openshift/bootstrap-in-place/master-update.fcc
@@ -37,6 +37,17 @@ storage:
       contents:
         local: bootstrap-in-place/bootstrap-in-place-post-reboot.sh
       mode: 0555
+    - path: /var/log/log-bundle-bootstrap-in-place-pre-reboot.tar.gz
+      contents:
+        local: log-bundle-bootstrap-in-place-pre-reboot.tar.gz
+    - path: /usr/local/bin/installer-masters-gather.sh
+      contents:
+        local: bin/installer-masters-gather.sh
+      mode: 0555
+    - path: /usr/local/bin/installer-gather.sh
+      contents:
+        local: bin/installer-master-bootstrap-in-place-gather.sh
+      mode: 0555
 systemd:
   units:
     - name: bootstrap-in-place-post-reboot.service

--- a/data/data/bootstrap/bootstrap-in-place/usr/local/bin/bootstrap-in-place.sh.template
+++ b/data/data/bootstrap/bootstrap-in-place/usr/local/bin/bootstrap-in-place.sh.template
@@ -29,15 +29,26 @@ if [ ! -f master-ignition.done ]; then
   curl --header "Accept:'application/vnd.coreos.ignition+json;version=3.1.0 ;q=0.1'" \
     http://localhost:22624/config/master -o /opt/openshift/original-master.ign
 
-  echo "Adding bootstrap control plane to master ignition"
+  GATHER_ID="bootstrap-in-place-pre-reboot"
+  GATHER_TAR_FILE=log-bundle-${GATHER_ID}.tar.gz
+
+  echo "Gathering installer bootstrap logs"
+  TAR_FILE=${GATHER_TAR_FILE} /usr/local/bin/installer-gather.sh --id $GATHER_ID
+
+  echo "Adding bootstrap control plane and bootstrap installer-gather bundle to master ignition"
   bootkube_podman_run \
     --rm \
     --privileged \
     --volume "$PWD:/assets:z" \
+    --volume "/usr/local/bin/:/assets/bin" \
     --volume "/var/lib/etcd/:/assets/etcd-data" \
     --volume "/etc/kubernetes:/assets/kubernetes" \
     "${CLUSTER_BOOTSTRAP_IMAGE}" \
-    bootstrap-in-place --asset-dir /assets --input  /assets/bootstrap-in-place/master-update.fcc --output /assets/master.ign
+    bootstrap-in-place \
+    --asset-dir /assets \
+    --input /assets/bootstrap-in-place/master-update.fcc \
+    --output /assets/master.ign
+
   touch master-ignition.done
 fi
 

--- a/data/data/bootstrap/bootstrap-in-place/usr/local/bin/installer-master-bootstrap-in-place-gather.sh
+++ b/data/data/bootstrap/bootstrap-in-place/usr/local/bin/installer-master-bootstrap-in-place-gather.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# This script is called instead of installer/data/data/bootstrap/files/usr/local/bin/installer-gather.sh for post-pivot
+# bootstrap-in-place log gathering.
+# Instead of gathering logs from the various masters, it simply runs the installer-masters-gather.sh script on itself.
+# Instead of gathering bootstrap logs from "itself", it unpacks the bundle transferred to it from the bootstrap phase
+# via the master ignition.
+
+if test "x${1}" = 'x--id'
+then
+	GATHER_ID="${2}"
+	shift 2
+fi
+
+ARTIFACTS="/tmp/bip-artifacts-${GATHER_ID}"
+MASTER_ARTIFACTS="/tmp/artifacts-${GATHER_ID}"
+mkdir -p "${ARTIFACTS}"
+
+exec &> >(tee "${ARTIFACTS}/gather.log")
+
+mkdir -p "${ARTIFACTS}/control-plane/master"
+sudo /usr/local/bin/installer-masters-gather.sh --id "${GATHER_ID}" </dev/null
+cp -r "$MASTER_ARTIFACTS"/* "${ARTIFACTS}/control-plane/master/"
+
+BOOTSTRAP_PHASE_LOG_BUNDLE_NAME="log-bundle-bootstrap-in-place-pre-reboot"
+BOOTSTRAP_PHASE_LOG_BUNDLE_ARCHIVE_PATH="/var/log/$BOOTSTRAP_PHASE_LOG_BUNDLE_NAME.tar.gz"
+
+if [[ -f $BOOTSTRAP_PHASE_LOG_BUNDLE_ARCHIVE_PATH ]]; then
+  echo "Found log bundle from bootstrap phase"
+  tar -xzf $BOOTSTRAP_PHASE_LOG_BUNDLE_ARCHIVE_PATH
+  cp -r $BOOTSTRAP_PHASE_LOG_BUNDLE_NAME/* "${ARTIFACTS}/"
+  rm -rf $BOOTSTRAP_PHASE_LOG_BUNDLE_NAME
+else
+  echo "Bootstrap phase logs not found, including only master logs in log bundle"
+fi
+
+TAR_FILE="${TAR_FILE:-${HOME}/log-bundle-${GATHER_ID}.tar.gz}"
+tar cz -C "${ARTIFACTS}" --transform "s?^\\.?log-bundle-${GATHER_ID}?" . > "${TAR_FILE}"
+echo "Log bundle written to ${TAR_FILE}"


### PR DESCRIPTION
Support collecting logs from bootstrap-in-place cluster with, for example, `openshift-install gather bootstrap --bootstrap 192.168.126.10 --master 192.168.126.10 --key id_rsa`

How it works:

# Pre-pivot - gather bootstrap only
The command works as usual before the pivot occurs because the `/usr/local/bin/installer-gather.sh` script is present and works as expected without any changes.

# Post-pivot - gather bootstrap & master logs

## Gathering bootstrap logs
Before reboot, bootstrap will gather from itself using `/usr/local/bin/installer-gather.sh`. This script also tries to gather from the masters in the cluster, but since there are none, it will only gather about itself.

After the gathering is complete, the bundle is added to the master ignition - thus making the bootstrap logs available from the master after reboot.

## Gathering master logs
Typically, in non-BiP scenarios, masters logs are gathered using the bootstrap node as a proxy by remotely running, via `ssh`, the `/usr/local/bin/installer-gather.sh` script present on the bootstrap node. That script in turn detects all masters (or receives a list of masters via the `--master` command-line arguments), then for each master it `scp`s a second script called `/usr/local/bin/installer-masters-gather.sh` to that master. It then runs that script remotely, on the master, using `ssh`. When the script is finished running, it `scp`s the resulting files back to the bootstrap node, adding them to the bootstrap log bundle, with each master logs appearing in its own named-folder inside the `control-plane` directory of the bootstrap node log bundle.

In the BiP scenario, we created a new script called `installer-master-bootstrap-in-place-gather.sh`. This script is copied to the master (using ignition) to the same location where the bootstrap node usually has `installer-gather.sh`. i.e. this script masquerades as `installer-gather.sh`. We also copy the `/usr/local/bin/installer-masters-gather.sh`.

The `installer-master-bootstrap-in-place-gather.sh`, masquerading as `installer-gather.sh`, gets remotely called by the `openshift-install gather` command that believes its collecting logs from a bootstrap node. The script however behaves slightly differently - instead of collecting bootstrap logs and then remotely running `/usr/local/bin/installer-masters-gather.sh` on all master nodes, it collects the bootstrap logs from the bundle copied to via the master-ignition, and it collect master logs by running `/usr/local/bin/installer-masters-gather.sh` directly on itself instead of remotely on other masters (which don't exist. All master IP addresses passed to it are completely ignored). The final archiving of all the logs into the home directory is done exactly in the same manner as `/usr/local/bin/installer-gather.sh`.

The end result is a log bundle that looks pretty much the same as non-bootstrap-in-place scenarios.

# Small caveat
As you can see - `openshift-install gather bootstrap --bootstrap 192.168.126.10 --master 192.168.126.10 --key id_rsa` - the command requires you to specify at least one master and one bootstrap node. In our case, you just pass the single node IP as both master and bootstrap. This causes a small "bug" when the node is pre-pivot - it collects both bootstrap logs on itself but also "remotely" collects master logs from itself via SSH. This causes a duplication of log files when the gather command is ran pre-pivot.





