### PR TITLE
BiP control plane gather

### DIFF
--- a/data/data/bootstrap/bootstrap-in-place/opt/openshift/bootstrap-in-place/bootstrap-in-place-post-reboot.sh
+++ b/data/data/bootstrap/bootstrap-in-place/opt/openshift/bootstrap-in-place/bootstrap-in-place-post-reboot.sh
@@ -53,6 +53,12 @@ function clean {
   if [ -d "/etc/kubernetes/bootstrap-secrets" ]; then
      rm -rf /etc/kubernetes/bootstrap-*
   fi
+
+  rm -rf /usr/local/bin/installer-gather.sh
+  rm -rf /usr/local/bin/installer-control-plane-gather.sh
+  rm -rf /usr/local/bin/installer-masters-gather.sh
+  rm -rf /var/log/log-bundle-bootstrap-in-place-pre-reboot.tar.gz
+
   systemctl disable bootstrap-in-place-post-reboot.service
 }
 

--- a/data/data/bootstrap/bootstrap-in-place/opt/openshift/bootstrap-in-place/master-update.fcc
+++ b/data/data/bootstrap/bootstrap-in-place/opt/openshift/bootstrap-in-place/master-update.fcc
@@ -48,6 +48,10 @@ storage:
       contents:
         local: bin/installer-master-bootstrap-in-place-gather.sh
       mode: 0555
+    - path: /usr/local/bin/installer-control-plane-gather.sh
+      contents:
+        local: bin/installer-control-plane-gather.sh
+      mode: 0555
 systemd:
   units:
     - name: bootstrap-in-place-post-reboot.service

--- a/data/data/bootstrap/bootstrap-in-place/usr/local/bin/installer-master-bootstrap-in-place-gather.sh
+++ b/data/data/bootstrap/bootstrap-in-place/usr/local/bin/installer-master-bootstrap-in-place-gather.sh
@@ -23,6 +23,12 @@ mkdir -p "${ARTIFACTS}/control-plane/master"
 sudo /usr/local/bin/installer-masters-gather.sh --id "${GATHER_ID}" </dev/null
 cp -r "$MASTER_ARTIFACTS"/* "${ARTIFACTS}/control-plane/master/"
 
+# shellcheck disable=SC2034
+GATHER_KUBECONFIG="/etc/kubernetes/bootstrap-secrets/kubeconfig"
+mkdir -p "${ARTIFACTS}/resources"
+source /usr/local/bin/installer-control-plane-gather.sh
+unset GATHER_KUBECONFIG
+
 BOOTSTRAP_PHASE_LOG_BUNDLE_NAME="log-bundle-bootstrap-in-place-pre-reboot"
 BOOTSTRAP_PHASE_LOG_BUNDLE_ARCHIVE_PATH="/var/log/$BOOTSTRAP_PHASE_LOG_BUNDLE_NAME.tar.gz"
 

--- a/data/data/bootstrap/files/usr/local/bin/installer-control-plane-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-control-plane-gather.sh
@@ -1,0 +1,55 @@
+# Collect cluster data
+function queue() {
+    local TARGET="${ARTIFACTS}/${1}"
+    shift
+    # shellcheck disable=SC2155
+    local LIVE="$(jobs | wc -l)"
+    while [[ "${LIVE}" -ge 45 ]]; do
+        sleep 1
+        LIVE="$(jobs | wc -l)"
+    done
+    # echo "${@}"
+    if [[ -n "${FILTER}" ]]; then
+        # shellcheck disable=SC2024
+        sudo KUBECONFIG="${GATHER_KUBECONFIG}" "${@}" | "${FILTER}" >"${TARGET}" &
+    else
+        # shellcheck disable=SC2024
+        sudo KUBECONFIG="${GATHER_KUBECONFIG}" "${@}" >"${TARGET}" &
+    fi
+}
+
+echo "Gathering cluster resources ..."
+queue resources/nodes.list oc --request-timeout=5s get nodes -o jsonpath --template '{range .items[*]}{.metadata.name}{"\n"}{end}'
+queue resources/masters.list oc --request-timeout=5s get nodes -o jsonpath -l 'node-role.kubernetes.io/master' --template '{range .items[*]}{.metadata.name}{"\n"}{end}'
+# ShellCheck doesn't realize that $ns is for the Go template, not something we're trying to expand in the shell
+# shellcheck disable=2016
+queue resources/containers oc --request-timeout=5s get pods --all-namespaces --template '{{ range .items }}{{ $name := .metadata.name }}{{ $ns := .metadata.namespace }}{{ range .spec.containers }}-n {{ $ns }} {{ $name }} -c {{ .name }}{{ "\n" }}{{ end }}{{ range .spec.initContainers }}-n {{ $ns }} {{ $name }} -c {{ .name }}{{ "\n" }}{{ end }}{{ end }}'
+queue resources/api-pods oc --request-timeout=5s get pods -l apiserver=true --all-namespaces --template '{{ range .items }}-n {{ .metadata.namespace }} {{ .metadata.name }}{{ "\n" }}{{ end }}'
+
+queue resources/apiservices.json oc --request-timeout=5s get apiservices -o json
+queue resources/clusteroperators.json oc --request-timeout=5s get clusteroperators -o json
+queue resources/clusterversion.json oc --request-timeout=5s get clusterversion -o json
+queue resources/configmaps.json oc --request-timeout=5s get configmaps --all-namespaces -o json
+queue resources/csr.json oc --request-timeout=5s get csr -o json
+queue resources/endpoints.json oc --request-timeout=5s get endpoints --all-namespaces -o json
+queue resources/events.json oc --request-timeout=5s get events --all-namespaces -o json
+queue resources/kubeapiserver.json oc --request-timeout=5s get kubeapiserver -o json
+queue resources/kubecontrollermanager.json oc --request-timeout=5s get kubecontrollermanager -o json
+queue resources/machineconfigpools.json oc --request-timeout=5s get machineconfigpools -o json
+queue resources/machineconfigs.json oc --request-timeout=5s get machineconfigs -o json
+queue resources/namespaces.json oc --request-timeout=5s get namespaces -o json
+queue resources/nodes.json oc --request-timeout=5s get nodes -o json
+queue resources/openshiftapiserver.json oc --request-timeout=5s get openshiftapiserver -o json
+queue resources/pods.json oc --request-timeout=5s get pods --all-namespaces -o json
+queue resources/rolebindings.json oc --request-timeout=5s get rolebindings --all-namespaces -o json
+queue resources/roles.json oc --request-timeout=5s get roles --all-namespaces -o json
+# this just lists names and number of keys
+queue resources/secrets-names.txt oc --request-timeout=5s get secrets --all-namespaces
+# this adds annotations, but strips out the SA tokens and dockercfg secrets which are noisy and may contain secrets in the annotations
+queue resources/secrets-names-with-annotations.txt oc --request-timeout=5s get secrets --all-namespaces -o=custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,TYPE:.type,ANNOTATIONS:.metadata.annotations | grep -v -- '-token-' | grep -v -- '-dockercfg-'
+queue resources/services.json oc --request-timeout=5s get services --all-namespaces -o json
+
+FILTER=gzip queue resources/openapi.json.gz oc --request-timeout=5s get --raw /openapi/v2
+
+echo "Waiting for logs ..."
+wait

--- a/data/data/bootstrap/files/usr/local/bin/installer-control-plane-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-control-plane-gather.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Collect cluster data
 function queue() {
     local TARGET="${ARTIFACTS}/${1}"

--- a/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
+++ b/data/data/bootstrap/files/usr/local/bin/installer-gather.sh
@@ -57,63 +57,12 @@ find "${ARTIFACTS}/rendered-assets" -name "*kubeconfig*" -print0 | xargs -0 rm
 find "${ARTIFACTS}/rendered-assets" -name "*.key" -print0 | xargs -0 rm
 find "${ARTIFACTS}/rendered-assets" -name ".kube" -print0 | xargs -0 rm -rf
 
-
-# Collect cluster data
-function queue() {
-    local TARGET="${ARTIFACTS}/${1}"
-    shift
-    # shellcheck disable=SC2155
-    local LIVE="$(jobs | wc -l)"
-    while [[ "${LIVE}" -ge 45 ]]; do
-        sleep 1
-        LIVE="$(jobs | wc -l)"
-    done
-    # echo "${@}"
-    if [[ -n "${FILTER}" ]]; then
-        # shellcheck disable=SC2024
-        sudo "${@}" | "${FILTER}" >"${TARGET}" &
-    else
-        # shellcheck disable=SC2024
-        sudo "${@}" >"${TARGET}" &
-    fi
-}
 mkdir -p "${ARTIFACTS}/control-plane" "${ARTIFACTS}/resources"
 
-echo "Gathering cluster resources ..."
-queue resources/nodes.list oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get nodes -o jsonpath --template '{range .items[*]}{.metadata.name}{"\n"}{end}'
-queue resources/masters.list oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get nodes -o jsonpath -l 'node-role.kubernetes.io/master' --template '{range .items[*]}{.metadata.name}{"\n"}{end}'
-# ShellCheck doesn't realize that $ns is for the Go template, not something we're trying to expand in the shell
-# shellcheck disable=2016
-queue resources/containers oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get pods --all-namespaces --template '{{ range .items }}{{ $name := .metadata.name }}{{ $ns := .metadata.namespace }}{{ range .spec.containers }}-n {{ $ns }} {{ $name }} -c {{ .name }}{{ "\n" }}{{ end }}{{ range .spec.initContainers }}-n {{ $ns }} {{ $name }} -c {{ .name }}{{ "\n" }}{{ end }}{{ end }}'
-queue resources/api-pods oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get pods -l apiserver=true --all-namespaces --template '{{ range .items }}-n {{ .metadata.namespace }} {{ .metadata.name }}{{ "\n" }}{{ end }}'
-
-queue resources/apiservices.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get apiservices -o json
-queue resources/clusteroperators.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get clusteroperators -o json
-queue resources/clusterversion.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get clusterversion -o json
-queue resources/configmaps.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get configmaps --all-namespaces -o json
-queue resources/csr.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get csr -o json
-queue resources/endpoints.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get endpoints --all-namespaces -o json
-queue resources/events.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get events --all-namespaces -o json
-queue resources/kubeapiserver.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get kubeapiserver -o json
-queue resources/kubecontrollermanager.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get kubecontrollermanager -o json
-queue resources/machineconfigpools.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get machineconfigpools -o json
-queue resources/machineconfigs.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get machineconfigs -o json
-queue resources/namespaces.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get namespaces -o json
-queue resources/nodes.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get nodes -o json
-queue resources/openshiftapiserver.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get openshiftapiserver -o json
-queue resources/pods.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get pods --all-namespaces -o json
-queue resources/rolebindings.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get rolebindings --all-namespaces -o json
-queue resources/roles.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get roles --all-namespaces -o json
-# this just lists names and number of keys
-queue resources/secrets-names.txt oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get secrets --all-namespaces
-# this adds annotations, but strips out the SA tokens and dockercfg secrets which are noisy and may contain secrets in the annotations
-queue resources/secrets-names-with-annotations.txt oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get secrets --all-namespaces -o=custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,TYPE:.type,ANNOTATIONS:.metadata.annotations | grep -v -- '-token-' | grep -v -- '-dockercfg-'
-queue resources/services.json oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get services --all-namespaces -o json
-
-FILTER=gzip queue resources/openapi.json.gz oc --kubeconfig=/opt/openshift/auth/kubeconfig --request-timeout=5s get --raw /openapi/v2
-
-echo "Waiting for logs ..."
-wait
+# shellcheck disable=SC2034
+GATHER_KUBECONFIG="/opt/openshift/auth/kubeconfig"
+source /usr/local/bin/installer-control-plane-gather.sh
+unset GATHER_KUBECONFIG
 
 echo "Gather remote logs"
 export MASTERS=()


### PR DESCRIPTION
Created new `installer-control-plane-gather.sh` file containing all `oc` commands from `installer-gather.sh` so it can be sourced by both `installer-gather.sh` and `installer-master-bootstrap-in-place-gather.sh`. 

Also cleaned up installer gather scripts/resources in post-reboot service teardown in `bootstrap-in-place/bootstrap-in-place-post-reboot.sh`:

```
rm -rf /usr/local/bin/installer-gather.sh
rm -rf /usr/local/bin/installer-control-plane-gather.sh
rm -rf /usr/local/bin/installer-masters-gather.sh
rm -rf /var/log/log-bundle-bootstrap-in-place-pre-reboot.tar.gz
```